### PR TITLE
Unify licenses

### DIFF
--- a/contracts/SBT.sol
+++ b/contracts/SBT.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/contracts/interfaces/IERC5192.sol
+++ b/contracts/interfaces/IERC5192.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface IERC5192 {


### PR DESCRIPTION
Use Apache 2.0 license everywhere.