### PR TITLE
Remove updateBaseURI 

### DIFF
--- a/contracts/SBT.sol
+++ b/contracts/SBT.sol
@@ -17,10 +17,6 @@ contract SBT is ERC721, ERC721Enumerable, Ownable {
         return baseURI;
     }
 
-    function updateBaseURI(string memory baseURI_) public onlyOwner {
-        baseURI = baseURI_;
-    }
-
     // Mapping from token ID to locked status
     mapping(uint256 => bool) _locked;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bisonai/sbt-contracts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Solidity smart contracts, deployment and test scripts for Soulbound token (SBT)",
   "files": [
     "dist"
@@ -21,26 +21,26 @@
   "devDependencies": {
     "@ethersproject/abi": "^5.4.7",
     "@ethersproject/providers": "^5.4.7",
-    "@openzeppelin/contracts": "^4.7.2",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.0",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "@nomicfoundation/hardhat-toolbox": "^1.0.1",
     "@nomiclabs/hardhat-ethers": "^2.1.0",
     "@nomiclabs/hardhat-etherscan": "^3.0.0",
     "@nomiclabs/hardhat-web3": "^2.0.0",
+    "@openzeppelin/contracts": "^4.7.2",
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.2",
     "@types/chai": "^4.2.0",
     "@types/mocha": "^9.1.0",
     "@types/node": ">=12.0.0",
     "chai": "^4.2.0",
+    "dotenv": "^16.0.1",
     "ethers": "^5.4.7",
     "hardhat": "^2.10.1",
     "hardhat-gas-reporter": "^1.0.8",
     "solidity-coverage": "^0.7.21",
     "ts-node": ">=8.0.0",
     "typechain": "^8.1.0",
-    "typescript": ">=4.5.0",
-    "dotenv": "^16.0.1"
+    "typescript": ">=4.5.0"
   }
 }

--- a/test/sbt.ts
+++ b/test/sbt.ts
@@ -79,11 +79,4 @@ describe('SBT', async function () {
     const checkStatus = await sbt.supportsInterface(interfaceId)
     expect(checkStatus == true)
   })
-
-  it('#10 Check updateBaseURI', async function () {
-    const newBaseURI = 'http://localhost/sbt/'
-    await sbt.updateBaseURI(newBaseURI)
-
-    expect(await sbt.tokenURI(tokenID0)).to.equal(newBaseURI + tokenID0.toString())
-  })
 })


### PR DESCRIPTION
This PR is ready for review. 

Changes:

- remove updateBaseURI from sbt contracts
- remove updateBaseURI from test
- bumb up version from `0.4.0` to `0.5.0` 